### PR TITLE
Recruiters who targetted my non-public employer email address

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -1,4 +1,5 @@
 @alexanderblackrecruitment.co.uk OR
+@alexanderash.com OR 
 @avantirecruitment.co.uk OR 
 @blueskiescareers.co.uk OR 
 @computerfutures.com OR 
@@ -10,6 +11,7 @@
 @greythorn.co.uk OR 
 @hays.com OR 
 @huntressgroup.com OR 
+@hydrogengroup.com OR 
 @it-talent.co.uk OR 
 @ithr.com OR 
 @marcusdonald.com OR 
@@ -25,6 +27,8 @@
 @recruit360.co.uk OR verticalit.co.uk OR 
 @redrockconsulting.co.uk OR 
 @syntaxconsultancy.com OR 
+@rethink-recruitment.com OR 
 @trentpearce.co.uk OR 
+@ulocate.eu OR
 @venngroup.com OR 
 @xcedesolutions.com 


### PR DESCRIPTION
Added list of recruiters who splattered my employer's email server with variants of my name in order to get through to me. Instead of using the email address I listed on my profile
