### PR TITLE
Last two weeks in recruitment

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -25,7 +25,6 @@
 @digitalgurus.co.uk OR 
 @direct-recruitment.co.uk OR 
 @e-recruiter.co.uk OR 
-@ecomrecruitment.com OR 
 @elitejobs.eu.com OR 
 @esynergy-solutions.co.uk OR 
 @etrust.org.uk OR 
@@ -51,7 +50,6 @@
 @jobstheword.co.uk OR 
 @jp-engineering.co.uk OR 
 @jp-jobs.com OR 
-@levesongower.co.uk OR 
 @marcusdonald.com OR 
 @matchtech.com OR 
 @mcgregor-boyall.com OR 
@@ -86,7 +84,6 @@
 @rightfutures.com OR 
 @roc-search.com OR 
 @senitor.com OR 
-@shareforce.co.uk OR 
 @sherborneselection.co.uk OR 
 @skillsearch.com OR 
 @spring.com OR 


### PR DESCRIPTION
Hi,

After double checking the list I'm pretty sure at least some recruiters in each domain I added are pretty spammy. If that also bans some better behaved recruiters in the same domain as a side effect, oh well, I'm not going to cry for them.

I first added all recruitment email over the last two weeks to the list, then double checked and reverted the few that seemed reasonably legit at the second glance.

A few lines got moved around by `sort` command.

If you have particular desire to see some of that spam forwarded to you for a proof, just ask.

Personally I prefer to just forward all that to a separate folder rather than autoreply (like spammers care), but to each their own.
