### PR TITLE
Add Boolerang.co.uk

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -29,6 +29,7 @@
 @axica-recruitment.com OR 
 @becomeuk.com OR 
 @bitwave-resource.co.uk OR 
+@boolerang.co.uk OR 
 @blueglue.co.uk OR 
 @blueskiescareers.co.uk OR 
 @brainit.co.uk OR 


### PR DESCRIPTION
Example email (effectively spammed twice):

```
Hi Team!
             
We had a few minor issues with our emails yesterday, so I thought I’d pop this over to you again just in case you hadn’t received it the first time.
 
Essential Intro - we're not a recruitment agency!
I saw David’s post on hnhiring.me regarding looking for Infrastructure/Software Engineers at FundApps in London, and thought you might be interested in what we do! We’re a market-leading jobs board that specialises in Developer/Tech Roles in London.

We’ve helped over 600 companies hire techies in London (Worldpay, BBC, Skyscanner, Deliveroo, etc), and our popular newsletter is received by over 15,000 London techies every week.

We have three listing options: 1) Basic Listings, which are 100% free, 2) Featured Listings, which receive 3-4x the number of page views/exposure, or 3) Boolerang Unlimited – an affordable monthly subscription that allows you to post Unlimited Featured Listings. You can check out the platform here, and click here to get started posting jobs! :)

Cheers!

Ed

Ed Beecroft / Team Lead
team@boolerang.co.uk
 
Boolerang
Shoreditch
London, E1
http://boolerang.co.uk
```