### PR TITLE
add opusrecruitmentsolutions.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -177,6 +177,7 @@
 @oho.co.uk OR 
 @oliverbernard.co.uk OR 
 @optimussearch.com OR 
+@opusrecruitmentsolutions.com OR 
 @opusrs.com OR 
 @opusrs.com.au OR 
 @oscar-associates.com OR 


### PR DESCRIPTION
`opusrs.com` is also known as `opusrecruitmentsolutions.com`.